### PR TITLE
[JCT] / 2023.08.29(화)

### DIFF
--- a/양재준/백트래킹/[JCT]_10971.js
+++ b/양재준/백트래킹/[JCT]_10971.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+let [N, ...cost] = fs.readFileSync('dev/stdin').toString().split('\n');
+N = Number(N);
+cost = cost.map((el) => el.split(' ').map(Number));
+
+let visited = Array(N).fill(false);
+visited[0] = true; // 중간에 시작지점으로 돌아오지 않게 visited 처리
+let min = 1000000 * 10 + 1;
+
+function dfs(city, depth, currentCost) {
+  if (depth === N - 1) {
+    if (cost[city][0] !== 0) {
+      let totalCost = currentCost + cost[city][0];
+      if (totalCost < min) {
+        min = totalCost;
+      }
+    }
+    return;
+  }
+
+  for (let i = 1; i < N; i++) {
+    if (visited[i] || cost[city][i] === 0) continue;
+    visited[i] = true;
+    dfs(i, depth + 1, currentCost + cost[city][i]);
+    visited[i] = false;
+  }
+}
+
+dfs(0, 0, 0);
+console.log(min);

--- a/양재준/백트래킹/[JCT]_10974.js
+++ b/양재준/백트래킹/[JCT]_10974.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const [N] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+let num = Array(N)
+  .fill()
+  .map((v, i) => i + 1); // [1,2,3, ... , N]
+let seq = [];
+let visited = Array(N).fill(false);
+let answer = '';
+
+function dfs(depth) {
+  if (depth === N) {
+    answer += seq.join(' ') + '\n';
+    return;
+  }
+
+  for (let i = 0; i < num.depth; i++) {
+    if (visited[i]) continue;
+    visited[i] = true;
+    seq.push(i + 1);
+    dfs(depth + 1);
+    seq.pop();
+    visited[i] = false;
+  }
+}
+
+dfs(0);
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_15649.js
+++ b/양재준/백트래킹/[JCT]_15649.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const [N, M] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+let seq = [];
+let visited = Array(N).fill(false);
+let answer = [];
+
+function dfs(depth) {
+  if (depth === M) {
+    answer += seq.join(' ') + '\n';
+    return;
+  }
+
+  for (let i = 0; i < N; i++) {
+    if (visited[i]) continue;
+    visited[i] = true;
+    seq.push(i + 1);
+    dfs(depth + 1);
+    seq.pop();
+    visited[i] = false;
+  }
+}
+
+dfs(0);
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_15650.js
+++ b/양재준/백트래킹/[JCT]_15650.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const [N, M] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+let seq = [];
+let visited = Array(N).fill(false);
+let answer = [];
+
+function dfs(depth) {
+  if (depth === M) {
+    let compare = [...seq];
+    if (JSON.stringify(seq) === JSON.stringify(compare.sort())) {
+      answer += seq.join(' ') + '\n';
+      return;
+    }
+  }
+
+  for (let i = 0; i < N; i++) {
+    if (visited[i]) continue;
+    visited[i] = true;
+    seq.push(i + 1);
+    dfs(depth + 1);
+    seq.pop();
+    visited[i] = false;
+  }
+}
+
+dfs(0);
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_15651.js
+++ b/양재준/백트래킹/[JCT]_15651.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const [N, M] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+let seq = [];
+let answer = [];
+
+function dfs(depth) {
+  if (depth === M) {
+    answer += seq.join(' ') + '\n';
+    return;
+  }
+
+  for (let i = 0; i < N; i++) {
+    seq.push(i + 1);
+    dfs(depth + 1);
+    seq.pop();
+  }
+}
+
+dfs(0);
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_15652.js
+++ b/양재준/백트래킹/[JCT]_15652.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const [N, M] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+let seq = [];
+let answer = '';
+
+function dfs(depth, start) {
+  if (depth === M) {
+    answer += seq.join(' ') + '\n';
+    return;
+  }
+
+  for (let i = start; i < N + 1; i++) {
+    seq.push(i);
+    dfs(depth + 1, i);
+    seq.pop();
+  }
+}
+
+dfs(0, 1);
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_1987.js
+++ b/양재준/백트래킹/[JCT]_1987.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+let [RC, ...board] = fs.readFileSync('dev/stdin').toString().split('\n');
+
+const [R, C] = RC.split(' ').map(Number);
+board = board.map((el) => el.trim().split(''));
+
+// 알파벳 개수 만큼 visited 배열
+const visited = Array(26).fill(false);
+const dx = [-1, 1, 0, 0];
+const dy = [0, 0, -1, 1];
+
+let maxCnt = 0;
+
+function dfs(depth, a, b) {
+  maxCnt = Math.max(maxCnt, depth);
+
+  for (let i = 0; i < 4; i++) {
+    const x = a + dx[i];
+    const y = b + dy[i];
+
+    // 보드의 범위를 벗어나는지 체크
+    if (x < 0 || x >= R || y < 0 || y >= C) continue;
+
+    // 알파벳의 인덱스 값을 가져와서 해당 인덱스의 visited를 체크
+    const index = board[x][y].charCodeAt(0) - 65;
+    if (visited[index]) continue;
+
+    visited[index] = true;
+    dfs(depth + 1, x, y);
+    visited[index] = false;
+  }
+}
+
+// 첫번째칸
+visited[board[0][0].charCodeAt(0) - 65] = true;
+dfs(1, 0, 0);
+console.log(maxCnt);

--- a/양재준/백트래킹/[JCT]_2529.js
+++ b/양재준/백트래킹/[JCT]_2529.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+let [k, operators] = fs.readFileSync('dev/stdin').toString().split('\n');
+
+k = Number(k);
+operators = operators.split(' ');
+
+let visited = Array(10).fill(false);
+let selected = [];
+let answer = [];
+
+// 이전 값과 넣을 값을 해당 연산자로 비교
+function possible(depth, i) {
+  if (depth === 0) return true;
+  const operator = operators[depth - 1];
+  if (operator === '>' && selected[depth - 1] < i) return false;
+  if (operator === '<' && selected[depth - 1] > i) return false;
+  return true;
+}
+
+function dfs(depth) {
+  if (depth === k + 1) {
+    answer.push(selected.join(''));
+    return;
+  }
+  for (let i = 0; i < 10; i++) {
+    if (visited[i]) continue;
+    if (possible(depth, i)) {
+      visited[i] = true;
+      selected.push(i);
+      dfs(depth + 1);
+      visited[i] = false;
+      selected.pop();
+    }
+  }
+}
+
+dfs(0);
+console.log(answer.at(-1) + '\n' + answer[0]);

--- a/양재준/백트래킹/[JCT]_2961.js
+++ b/양재준/백트래킹/[JCT]_2961.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+let [N, ...SB] = fs.readFileSync('dev/stdin').toString().split('\n');
+N = Number(N);
+SB = SB.map((el) => el.split(' ').map(Number));
+
+let result = [];
+let visited = Array(N).fill(false);
+let answer = 1e9;
+
+function dfs(depth, start) {
+  if (depth >= 1) {
+    // 1개 이상의 재료를 사용하였을때 결과 계산
+    let totalS = 1;
+    let totalB = 0;
+    for (let i of result) {
+      let [s, b] = SB[i];
+      totalS *= s;
+      totalB += b;
+    }
+    answer = Math.min(answer, Math.abs(totalS - totalB));
+  }
+
+  for (let i = start; i < N; i++) {
+    if (visited[i]) continue;
+    visited[i] = true;
+    result.push(i);
+    dfs(depth + 1, i + 1);
+    visited[i] = false;
+    result.pop();
+  }
+}
+
+dfs(0, 0);
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_6603.js
+++ b/양재준/백트래킹/[JCT]_6603.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+let input = fs.readFileSync('dev/stdin').toString().split('\n');
+const len = input.length;
+
+let visited = Array(50).fill(false);
+let result = [];
+function dfs(depth, start, data) {
+  if (depth === 6) {
+    console.log(...result);
+    return;
+  }
+
+  for (let j = start; j < data.length; j++) {
+    const num = data[j];
+    if (visited[num]) continue;
+    visited[num] = true;
+    result.push(num);
+    dfs(depth + 1, j, data);
+    result.pop();
+    visited[num] = false;
+  }
+}
+
+for (let i = 0; i < len; i++) {
+  const [k, ...data] = input[i].split(' ').map(Number);
+  if (k === 0) break;
+
+  result = [];
+  dfs(0, 0, data);
+  console.log();
+}

--- a/양재준/백트래킹/[JCT]_7490.js
+++ b/양재준/백트래킹/[JCT]_7490.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+let [caseNum, ...cases] = fs.readFileSync('dev/stdin').toString().split('\n');
+
+caseNum = Number(caseNum);
+cases = cases.map(Number);
+
+let answer = '';
+for (let i = 0; i < caseNum; i++) {
+  const N = cases[i];
+  solution(1, 2, N);
+  answer += '\n';
+}
+
+function solution(acc, n, limit) {
+  // 누적된 식 + 연산자 + current
+  let current = n;
+  let next = n + 1;
+
+  if (n > limit) {
+    let sum = eval(acc.replace(/ /g, '')); // 공백 없애주고 eval로 값 계산
+    if (sum === 0) answer += acc + '\n';
+    return;
+  }
+
+  // 모든 경우에 대한 연산식을 얻기 위해 각각의 연산자에 대해 재귀함수를 호출
+  solution(acc + ' ' + current, next, limit);
+  solution(acc + '+' + current, next, limit);
+  solution(acc + '-' + current, next, limit);
+}
+
+console.log(answer);

--- a/양재준/백트래킹/[JCT]_9663.js
+++ b/양재준/백트래킹/[JCT]_9663.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+let N = Number(fs.readFileSync('dev/stdin').toString());
+
+let cnt = 0;
+let queens = [];
+
+function possible(x, y) {
+  for (let [a, b] of queens) {
+    if (a === x || b === y) return false;
+    if (Math.abs(x - a) === Math.abs(y - b)) return false;
+  }
+  return true;
+}
+
+function dfs(depth) {
+  if (depth === N) {
+    cnt++;
+    return;
+  }
+
+  for (let i = 0; i < N; i++) {
+    if (!possible(depth, i)) continue;
+    queens.push([depth, i]);
+    dfs(depth + 1);
+    queens.pop();
+  }
+}
+
+dfs(0);
+console.log(cnt);


### PR DESCRIPTION
## 내용

구현 완료한 문제유형 ( ex 입출력, 조건문 , 반복문 구현 완료 )

close #82 

---

## 느낀 점 & 궁금한 점

강의 예제 문제였던 N퀸 문제가 코드를 봐도 이해가 안돼서 몇 시간은 붙잡고 있었네요..

```javascript
for (let i = 0; i < N; i++) {
    if (visited[i]) continue;
    visited[i] = true;
    seq.push(i + 1);
    dfs(depth + 1);
    seq.pop();
    visited[i] = false;
  }
```

일단 이렇게 깔아두고, 상황에 따라서 visited 조건을 바꿔주던지, 재귀함수의 탈출 조건에서 어떠한 처리를 해주던지 하는 경우가 많았던거 같습니다.

### 15649, 15650, 15651, 15652
15649를 해결하면 그 코드를 바탕으로 다른 문제는 쉽게 해결이 가능했던거 같습니다. 15650에서 저는 우선 배열을 만든 다음 오름차순인지 체크 하였는데, 강의 코드방식인 애초에 start 값을 주어서 오름차순이 되도록 해주는게 훨씬 효율적인 방법인거 같습니다. 그래서 15652에서는 start 값으로 해결하였습니다.

### 7490
이 문제는 어짜피 모든 경우를 다 체크해야 할거 같아서, 그냥 재귀함수를 통해 문자열로 된 연산식을 만들어주고, eval로 값을 계산 했습니다.

### 10971
방문한 경우와 다음 도시로 이동할 수 없는 경우 재귀함수를 호출하지 않는 방식으로 해결했습니다.

### 2961
저는 재료가 1개일때, 2개일때, ... N개일때의 신맛 쓴맛을 구하려고 했는데 이때 잠시 집중력이 흐트러져서 계속 원하는 값이 안나왔습니다. 그래서 강의 답안을 참고 했습니다.

### 1987
구름챌린지에서 비슷한 문제를 풀었던게 도움이 됐던거 같습니다.
처음엔 알파벳이 순서대로 들어있는 배열과 알파벳 개수 만큼의 visited 배열을 만들어서 알파벳 배열에서 인덱스 값을 구한 다음 visited 배열을 방문처리 해줬는데 시간초과가 나서 방법을 찾아보다 charCodeAt으로 문자의 유니코드 값을 가져와 인덱스 값으로 사용했더니 통과됐습니다.

### 2529
이전에 넣었던 값과 이번에 넣을 값을 연산자로 비교해서 참일 경우만 재귀함수를 호출하는 방식으로 풀었습니다.

