### PR TITLE
[JCT] / 2023.09.19(화)

### DIFF
--- a/양재준/BFS/[JCT]_14395.js
+++ b/양재준/BFS/[JCT]_14395.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+let [s, t] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+class Queue {
+  constructor() {
+    this.items = {};
+    this.headIndex = 0;
+    this.tailIndex = 0;
+  }
+
+  enqueue(item) {
+    this.items[this.tailIndex] = item;
+    this.tailIndex++;
+  }
+  dequeue() {
+    const item = this.items[this.headIndex];
+    delete this.items[this.headIndex];
+    this.headIndex++;
+    return item;
+  }
+  peek() {
+    return this.items[this.headIndex];
+  }
+  getLength() {
+    return this.tailIndex - this.headIndex;
+  }
+}
+
+// 최대 최소 값
+const min = 1;
+const max = 10e9;
+
+// 연산자 정의 '*', '+', '-', '/' 순서
+const operator1 = (num) => num * num;
+const operator2 = (num) => num + num;
+const operator3 = (num) => 0; // 의미있는 연산자인지?
+const operator4 = (num) => 1;
+// 범위를 벗어나는지 체크
+const possible = (num) => min <= num && num <= max;
+
+let minLength = 0;
+const answer = [];
+function bfs(s, t) {
+  if (s === t) return 0;
+  const queue = new Queue();
+  const visited = new Set();
+  queue.enqueue({
+    num: s,
+    operator: '',
+  });
+
+  visited.add(s);
+
+  while (queue.getLength() != 0) {
+    const { num, operator } = queue.dequeue();
+    if (num === t) {
+      // 최소 연산 횟수일때 정답 배열에 연산자를 push
+      const operatorLength = operator.length;
+      minLength = minLength === 0 ? operatorLength : Math.min(minLength, operatorLength);
+      if (operatorLength <= minLength) {
+        answer.push(operator);
+      }
+    }
+
+    // 연산자 순회하면서 조건에 맞을 경우 enqueue
+    [operator1, operator2, operator3, operator4].forEach((op, index) => {
+      const nextNum = op(num);
+      if (possible(nextNum) && !visited.has(nextNum)) {
+        queue.enqueue({
+          num: nextNum,
+          operator: operator + ['*', '+', '-', '/'][index],
+        });
+        visited.add(nextNum);
+      }
+    });
+  }
+
+  // 바꿀수 없는 경우 -1 return
+  if (answer.length == 0) return -1;
+  // 바꿀수 있는 경우 1 return
+  else return 1;
+}
+
+const result = bfs(s, t);
+
+if (result <= 0) console.log(result);
+else console.log(answer.sort().shift());

--- a/양재준/BFS/[JCT]_1697.js
+++ b/양재준/BFS/[JCT]_1697.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const [N, K] = fs.readFileSync('dev/stdin').toString().split(' ').map(Number);
+
+class Queue {
+  constructor() {
+    this.items = {};
+    this.headIndex = 0;
+    this.tailIndex = 0;
+  }
+
+  enqueue(item) {
+    this.items[this.tailIndex] = item;
+    this.tailIndex++;
+  }
+  dequeue() {
+    const item = this.items[this.headIndex];
+    delete this.items[this.headIndex];
+    this.headIndex++;
+    return item;
+  }
+  peek() {
+    return this.items[this.headIndex];
+  }
+  getLength() {
+    return this.tailIndex - this.headIndex;
+  }
+}
+
+const visited = Array(100001).fill(false);
+
+// 방문하지 않았고, 유효한 범위 내에 있을때 enqueue
+const possible = (value) => !visited[value] && 0 <= value && value <= 100000;
+
+function bfs(N, K) {
+  const queue = new Queue();
+  // 좌표 값과 cost를 enqueue
+  queue.enqueue({
+    position: N,
+    cost: 0,
+  });
+
+  while (queue.getLength() != 0) {
+    const { position, cost } = queue.dequeue();
+
+    // 좌표가 K이면 cost를 return
+    if (position === K) return cost;
+
+    visited[position] = true;
+
+    // enqueue 할때 cost를 누적해서 증가시켜준다
+    if (possible(position - 1)) queue.enqueue({ position: position - 1, cost: cost + 1 });
+    if (possible(position + 1)) queue.enqueue({ position: position + 1, cost: cost + 1 });
+    if (possible(position * 2)) queue.enqueue({ position: position * 2, cost: cost + 1 });
+  }
+}
+console.log(bfs(N, K));

--- a/양재준/BFS/[JCT]_1707.js
+++ b/양재준/BFS/[JCT]_1707.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+let [K, ...input] = fs.readFileSync('dev/stdin').toString().split('\n');
+K = Number(K);
+
+class Queue {
+  constructor() {
+    this.items = {};
+    this.headIndex = 0;
+    this.tailIndex = 0;
+  }
+
+  enqueue(item) {
+    this.items[this.tailIndex] = item;
+    this.tailIndex++;
+  }
+  dequeue() {
+    const item = this.items[this.headIndex];
+    delete this.items[this.headIndex];
+    this.headIndex++;
+    return item;
+  }
+  peek() {
+    return this.items[this.headIndex];
+  }
+  getLength() {
+    return this.tailIndex - this.headIndex;
+  }
+}
+const [NO_GROUP, GROUP1, GROUP2] = [0, 1, 2];
+function bfs(graph, group, length) {
+  const queue = new Queue();
+  for (let i = 1; i < length; i++) {
+    if (group[i] === NO_GROUP) {
+      queue.enqueue(i);
+      group[i] = GROUP1;
+
+      while (queue.getLength() != 0) {
+        const node = queue.dequeue();
+        const neighborGroup = group[node] === GROUP1 ? GROUP2 : GROUP1;
+
+        for (const neighbor of graph[node]) {
+          if (group[neighbor] === NO_GROUP) {
+            queue.enqueue(neighbor);
+            group[neighbor] = neighborGroup;
+          } else if (group[neighbor] !== neighborGroup) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+let index = 0;
+for (let i = 0; i < K; i++) {
+  const [V, E] = input[index].split(' ').map(Number);
+  const graph = Array.from(Array(V + 1), () => new Array());
+  const group = Array(V + 1).fill(0);
+
+  for (let j = 1; j <= E; j++) {
+    const [x, y] = input[index + j].split(' ').map(Number);
+    graph[x].push(y);
+    graph[y].push(x);
+  }
+
+  console.log(bfs(graph, group, V) ? 'YES' : 'NO');
+  index += E + 1;
+}

--- a/양재준/BFS/[JCT]_18352.js
+++ b/양재준/BFS/[JCT]_18352.js
@@ -1,0 +1,75 @@
+class Queue {
+  constructor() {
+    this.items = {};
+    this.headIndex = 0;
+    this.tailIndex = 0;
+  }
+
+  enqueue(item) {
+    this.items[this.tailIndex] = item;
+    this.tailIndex++;
+  }
+  dequeue() {
+    const item = this.items[this.headIndex];
+    delete this.items[this.headIndex];
+    this.headIndex++;
+    return item;
+  }
+  peek() {
+    return this.items[this.headIndex];
+  }
+  getLength() {
+    return this.tailIndex - this.headIndex;
+  }
+}
+const fs = require('fs');
+let input = fs.readFileSync('dev/stdin').toString().trim().split('\n');
+const [N, M, K, X] = input[0].trim().split(' ').map(Number);
+
+const graph = Array(N + 1)
+  .fill()
+  .map(() => []);
+
+for (let i = 1; i <= M; i++) {
+  const [a, b] = input[i].trim().split(' ').map(Number);
+  graph[a].push(b);
+}
+
+const visited = Array(N + 1).fill(false);
+let answer = [];
+function bfs(start) {
+  const queue = new Queue();
+  visited[X] = true;
+  // 도시와 거리 enqueue
+  queue.enqueue({
+    city: start,
+    cost: 0,
+  });
+
+  while (queue.getLength() != 0) {
+    const { city, cost } = queue.dequeue();
+
+    // 거리가 K 일때 정답 배열에 push, K초과 일때는 체크할 필요가 없으므로 return
+    if (cost === K) answer.push(city);
+    if (cost > K) return;
+
+    for (let nextCity of graph[city]) {
+      if (!visited[nextCity]) {
+        visited[nextCity] = true;
+        queue.enqueue({
+          city: nextCity,
+          cost: cost + 1,
+        });
+      }
+    }
+  }
+}
+
+bfs(X);
+if (answer.length === 0) console.log(-1);
+else {
+  answer.sort((a, b) => a - b);
+  for (let i = 0; i < answer.length; i++) {
+    console.log(answer[i]);
+  }
+}

--- a/양재준/BFS/[JCT]_18405.js
+++ b/양재준/BFS/[JCT]_18405.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+let [NK, ...graph] = fs.readFileSync('dev/stdin').toString().trim().split('\n');
+const [N, K] = NK.trim().split(' ').map(Number);
+const [S, X, Y] = graph.pop().trim().split(' ').map(Number);
+graph = graph.map((el) => el.trim().split(' ').map(Number));
+
+const dx = [-1, 1, 0, 0];
+const dy = [0, 0, -1, 1];
+
+class Queue {
+  constructor() {
+    this.items = {};
+    this.headIndex = 0;
+    this.tailIndex = 0;
+  }
+
+  enqueue(item) {
+    this.items[this.tailIndex] = item;
+    this.tailIndex++;
+  }
+  dequeue() {
+    const item = this.items[this.headIndex];
+    delete this.items[this.headIndex];
+    this.headIndex++;
+    return item;
+  }
+  peek() {
+    return this.items[this.headIndex];
+  }
+  getLength() {
+    return this.tailIndex - this.headIndex;
+  }
+}
+
+const initVirus = Array(K + 1)
+  .fill()
+  .map(() => []);
+
+const visited = Array.from(Array(N), () => Array(N).fill(false));
+
+for (let i = 0; i < N; i++) {
+  for (let j = 0; j < N; j++) {
+    if (graph[i][j] === 0) continue;
+    initVirus[graph[i][j]].push([i, j]);
+  }
+}
+
+function bfs() {
+  const queue = new Queue();
+  for (let i = 1; i <= K; i++) {
+    for (const [a, b] of initVirus[i]) {
+      queue.enqueue({
+        virus: i,
+        position: [a, b],
+        time: 0,
+      });
+      visited[a][b] = true;
+    }
+  }
+
+  while (queue.getLength() != 0) {
+    const { virus, position, time } = queue.dequeue();
+    const [x, y] = position;
+    if (time === S) return;
+
+    for (let i = 0; i < 4; i++) {
+      const nx = x + dx[i];
+      const ny = y + dy[i];
+
+      if (nx < 0 || nx > N - 1 || ny < 0 || ny > N - 1) continue;
+      if (!visited[nx][ny] && (graph[nx][ny] == 0 || virus < graph[nx][ny])) {
+        queue.enqueue({
+          virus: virus,
+          position: [nx, ny],
+          time: time + 1,
+        });
+        graph[nx][ny] = virus;
+        visited[nx][ny] = true;
+      }
+    }
+  }
+}
+
+bfs();
+console.log(graph[X - 1][Y - 1]);

--- a/양재준/BFS/[JCT]_7562.js
+++ b/양재준/BFS/[JCT]_7562.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+let [T, ...input] = fs.readFileSync('dev/stdin').toString().split('\n');
+T = Number(T);
+
+class Queue {
+  constructor() {
+    this.items = {};
+    this.headIndex = 0;
+    this.tailIndex = 0;
+  }
+
+  enqueue(item) {
+    this.items[this.tailIndex] = item;
+    this.tailIndex++;
+  }
+  dequeue() {
+    const item = this.items[this.headIndex];
+    delete this.items[this.headIndex];
+    this.headIndex++;
+    return item;
+  }
+  peek() {
+    return this.items[this.headIndex];
+  }
+  getLength() {
+    return this.tailIndex - this.headIndex;
+  }
+}
+
+const coordinate = [
+  [-1, -2],
+  [-2, -1],
+  [-2, 1],
+  [-1, 2],
+  [1, 2],
+  [2, 1],
+  [2, -1],
+  [1, -2],
+];
+
+let index = 0;
+
+const possible = (a, b, l) => {
+  if (a < 0 || a >= l || b < 0 || b >= l) return false;
+  return true;
+};
+function bfs(start, end, visited, l) {
+  const [endX, endY] = end;
+  const queue = new Queue();
+  // 좌표 값과 cost를 enqueue
+  queue.enqueue({
+    position: start,
+    cost: 0,
+  });
+
+  // 시작점 방문처리
+  visited[start[0]][start[1]] = true;
+
+  while (queue.getLength() != 0) {
+    const { position, cost } = queue.dequeue();
+    const [x, y] = position;
+
+    if (x === endX && y === endY) return cost;
+
+    for (let newCoordinate of coordinate) {
+      // 이동할 방향
+      const nx = x + newCoordinate[0];
+      const ny = y + newCoordinate[1];
+
+      // 이동이 가능한지 체크
+      if (possible(nx, ny, l) && !visited[nx][ny]) {
+        queue.enqueue({
+          position: [nx, ny],
+          cost: cost + 1,
+        });
+        // 방문처리
+        visited[nx][ny] = true;
+      }
+    }
+  }
+}
+
+for (let i = 0; i < T; i++) {
+  const l = +input[index];
+  const start = input[index + 1].split(' ').map(Number);
+  const end = input[index + 2].split(' ').map(Number);
+  const visited = Array.from(Array(l), () => Array(l).fill(false));
+
+  console.log(bfs(start, end, visited, l));
+
+  index += 3;
+}


### PR DESCRIPTION
## 내용

BFS 구현

close #104 

## 느낀 점 & 궁금한 점

이론 강의에서 제공해준 큐와 bfs 템플릿을 활용해서 풀었습니다.

### 1697

큐에 push 해줄 때 좌표 값과 누적되는 초를 같이 enqueue 해주고, 

목적지에 도달 했을때 누적된 초를 반환해주는 방식으로 풀었습니다.

### 7562

나이트가 이동이 가능한지 체크하고 가능할 경우 좌표와 이동 횟수를 enqueue 해주었습니다.

### 1707

이 문제는 해결 아이디어가 떠오르지 않아, 정답 강의의 해결 아이디어를 참고하여 풀었습니다.

방문자 배열을 그룹을 저장하는 배열로 활용하여 인접 요소의 경우 다른 그룹을 저장해주고, 

반복문에서 이미 저장된 그룹이 조건과 맞지 않을 경우 false를 리턴하는 방식으로 풀었습니다.

### 14395

아스키코드 순서에 따라 지정된 연산를 수행하는 함수를 만들어 주고,

큐에 연산 결과와 연산자를 문자열 형태로 누적시켜 주었습니다.

T가 0보다 크므로 마이너스 연산자는 애초에 고려하지 않아도 되지 않나 라는 생각이 드네요.

### 18405

바이러스가 퍼질 수 있는 조건을 체크하는게 조금 까다로웠던거 같습니다.

### 18352

다른 문제들과 비슷하게 거리를 누적 시켜가며 enqueue 해주고 거리가 K일때 정답 배열에 도시 번호를 push 해주었습니다.

